### PR TITLE
[list-exports] [fix] don't list <export>/ as exported

### DIFF
--- a/packages/list-exports/index.js
+++ b/packages/list-exports/index.js
@@ -37,6 +37,7 @@ function traverseDir(
 		packageDir,
 		process,
 		addError,
+		skipSlashExport,
 	},
 ) {
 	const slicedDir = dir.slice(packageDir.length + 1);
@@ -48,6 +49,7 @@ function traverseDir(
 			isMain: true,
 			file: mainFile,
 			usingExports,
+			skipSlashExport,
 		});
 	} else if (fs.existsSync(path.join(dir, 'package.json'))) {
 		addError(`\`${dirRelative}\` has a \`package.json\`, but either lacks a \`main\`, or its \`main\` is invalid!`);
@@ -213,11 +215,12 @@ module.exports = async function listExports(packageJSON) {
 		isMain,
 		file: pkgRelativeFilename,
 		usingExports,
+		skipSlashExport,
 	}) {
 		let specifiers;
 		if (isCJS(pkgRelativeFilename, usingExports)) {
 			specifiers = isMain
-				? [dir, `${dir.replace(/\/$/, '')}/`]
+				? skipSlashExport ? [dir] : [dir, `${dir.replace(/\/$/, '')}/`]
 				: [
 					pkgRelativeFilename,
 					pkgRelativeFilename.slice(0, -path.extname(pkgRelativeFilename).length),
@@ -274,6 +277,7 @@ module.exports = async function listExports(packageJSON) {
 					packageDir,
 					process: processPreExportsFile,
 					addError,
+					skipSlashExport: true,
 				});
 			} else {
 				const specifier = lhs === '.' ? '' : lhs;

--- a/packages/tests/fixtures/preact/expected.json
+++ b/packages/tests/fixtures/preact/expected.json
@@ -7,7 +7,6 @@
 	"binaries": [],
 	"require": [
 		"preact",
-		"preact/",
 		"preact/compat",
 		"preact/compat/",
 		"preact/compat/dist/compat",
@@ -296,7 +295,6 @@
 			"dist": {
 				"preact.js": [
 					"preact",
-					"preact/",
 					"preact/dist/preact",
 					"preact/dist/preact.js"
 				],


### PR DESCRIPTION
E.g. in package "test" with exports

```
{
  "./": "./",
  "./src/": "./src/"
}
```

in a package containing files `src/index.js` and `lib/index.js`,
you can import `test/src`, `test/lib` and `test/lib/` but not
`test/src/`