### PR TITLE
[list-exports] [fix] don't normalize rhs values of export objects

### DIFF
--- a/packages/list-exports/index.js
+++ b/packages/list-exports/index.js
@@ -328,7 +328,7 @@ module.exports = async function listExports(packageJSON) {
 									errors.push(`\`exports.${specifier ? `${lhs}.` : ''}${key}\`: ${targetValue} must start with \`./\` and must not contain \`node_modules\``);
 								}
 							} else if (targetValue != null) {
-								processRHSItem(normalizeExports(targetValue)['.'], [
+								processRHSItem(targetValue, [
 									'default',
 									'node',
 								].concat(

--- a/packages/tests/fixtures/single-spa-layout/expected.json
+++ b/packages/tests/fixtures/single-spa-layout/expected.json
@@ -6,30 +6,12 @@
 	},
 	"binaries": [],
 	"require": [
-		"single-spa-layout"
 	],
 	"import": [
-		"single-spa-layout"
 	],
 	"files": [
-		"./dist/esm/single-spa-layout.min.js",
-		"./dist/umd/single-spa-layout.min.js"
 	],
 	"tree": {
-		"single-spa-layout": {
-			"dist": {
-				"umd": {
-					"single-spa-layout.min.js": [
-						"single-spa-layout"
-					]
-				},
-				"esm": {
-					"single-spa-layout.min.js": [
-						"single-spa-layout"
-					]
-				}
-			}
-		}
 	},
 	"require (pre-exports)": [
 		"single-spa-layout",


### PR DESCRIPTION
This normalizing went haywire when it got an object with
keys that looked like paths, while at this location every
key is considered a condition, not an export path.