### PR TITLE
[Tests] add `conditions` ordering tests/fixture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,14 @@ import:
  - ljharb/travis-ci:node/minors/11.yml
  - ljharb/travis-ci:node/pretest.yml
 # - ljharb/travis-ci:node/posttest.yml
+before_install:
+  - 'case "${TRAVIS_NODE_VERSION}" in 0.*) export NPM_CONFIG_STRICT_SSL=false ;; esac'
+  - 'if [ -n "${CONDITIONS-}" ]; then cd packages/tests; fi'
+install:
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.5" ] || [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.7" ] || [ "${TRAVIS_NODE_VERSION}" = "0.9" ]; then nvm install --latest-npm 0.8 && npm install && nvm use "${TRAVIS_NODE_VERSION}"; else npm install; fi;'
 script:
   - 'if [ -n "${ENGINES-}" ]; then npx lerna exec ls-engines; fi'
+  - 'if [ -n "${CONDITIONS-}" ]; then cd ../.. && node packages/tests/conditions.js; fi'
 matrix:
   fast_finish: true
   include:
@@ -60,5 +66,37 @@ matrix:
       env: TEST=true SKIP_CLI=true ALLOW_FAILURE=true
     - node_js: "10.0"
       env: TEST=true SKIP_CLI=true
+    - node_js: "13.7"
+      env: CONDITIONS=true
+    - node_js: "13.6"
+      env: CONDITIONS=true
+    - node_js: "13.2"
+      env: CONDITIONS=true
+    - node_js: "13.1"
+      env: CONDITIONS=true
+    - node_js: "13.0"
+      env: CONDITIONS=true
+    - node_js: "12.17"
+      env: CONDITIONS=true
+    - node_js: "12.16"
+      env: CONDITIONS=true
+    - node_js: "8"
+      env: CONDITIONS=true
+    - node_js: "6"
+      env: CONDITIONS=true
+    - node_js: "4"
+      env: CONDITIONS=true
+    - node_js: "iojs"
+      env: CONDITIONS=true
+    - node_js: "0.12"
+      env: CONDITIONS=true
+    - node_js: "0.10"
+      env: CONDITIONS=true
+    - node_js: "0.8"
+      env: CONDITIONS=true
+    - node_js: "0.6"
+      env: CONDITIONS=true
   allow_failures:
     - env: TEST=true SKIP_CLI=true ALLOW_FAILURE=true
+    - node_js: "0.6"
+      env: CONDITIONS=true

--- a/packages/tests/.eslintrc
+++ b/packages/tests/.eslintrc
@@ -6,4 +6,12 @@
 	"parserOptions": {
 		"ecmaVersion": 2018,
 	},
+
+	"rules": {
+		"complexity": 0,
+		"func-style": 0,
+		"id-length": 0,
+		"max-lines-per-function": 0,
+		"no-negated-condition": 0,
+	},
 }

--- a/packages/tests/conditions-expected.js
+++ b/packages/tests/conditions-expected.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var semver = require('semver');
+var entries = require('object.entries');
+var fromEntries = require('object.fromentries');
+
+var hasBrokenExports = semver.satisfies(process.version, '~13.0 || ~13.1', { includePrerelease: true });
+var hasPackageExports = require('has-package-exports');
+var hasConditions = require('has-package-exports/conditional');
+
+var conditionsPkg = JSON.parse(String(fs.readFileSync(path.join(__dirname, './fixtures/conditions/project/package.json'))));
+
+var empty = {};
+
+function makeResult(slug) {
+	return {
+		resolved: path.basename(path.join(__dirname, 'fixtures/conditions/project/' + slug + '.js')),
+		result: slug
+	};
+}
+
+module.exports = function getExpectedConditions(resolve) {
+	var expected = {
+		'.': makeResult(hasBrokenExports ? 'fallback' : hasPackageExports ? 'default' : 'main'),
+		'package.json': {
+			resolved: path.basename(resolve('./fixtures/conditions/project/package.json')),
+			result: empty
+		},
+		dnri: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'dnri'),
+		dnir: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'dnir'),
+		drni: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'drni'),
+		drin: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'drin'),
+		dinr: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'dinr'),
+		dirn: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'dirn'),
+		ndri: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'ndri'),
+		ndir: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'ndir'),
+		nrdi: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'nrdi'),
+		nrid: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'nrid'),
+		nidr: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'nidr'),
+		nird: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'nird'),
+		rdni: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'rdni'),
+		rdin: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'rdin'),
+		rndi: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'rndi'),
+		rnid: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'rnid'),
+		ridn: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'ridn'),
+		rind: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'rind'),
+		idnr: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'idnr'),
+		idrn: makeResult(hasPackageExports ? hasBrokenExports ? 'fallback' : 'default' : 'idrn'),
+		indr: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'indr'),
+		inrd: makeResult(hasPackageExports ? hasConditions ? 'node' : hasBrokenExports ? 'fallback' : 'default' : 'inrd'),
+		irdn: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'irdn'),
+		irnd: makeResult(hasPackageExports ? hasConditions ? 'require' : hasBrokenExports ? 'fallback' : 'default' : 'irnd')
+	};
+
+	var actual = fromEntries(entries(expected).map(function (entry) {
+		var result;
+		var resolved;
+		try {
+			var exportPath = entry[0] === '.' ? 'conditions' : 'conditions/' + entry[0];
+			// eslint-disable-next-line global-require
+			result = entry[0] === 'package.json' ? empty : require(exportPath);
+			resolved = path.basename(resolve(exportPath));
+		} catch (e) {
+			result = e;
+		}
+		return [entry[0], {
+			resolved: resolved,
+			result: result
+		}];
+	}));
+
+	return {
+		actual: actual,
+		'package': conditionsPkg,
+		expected: expected
+	};
+};

--- a/packages/tests/conditions.js
+++ b/packages/tests/conditions.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var test = require('tape');
+var semver = require('semver');
+var whyNotEqual = require('is-equal/why');
+var forEach = require('for-each');
+var resolve = require('resolve');
+
+var hasBrokenExports = semver.satisfies(process.version, '~13.0 || ~13.1', { includePrerelease: true });
+var hasPackageExports = require('has-package-exports');
+var hasConditions = require('has-package-exports/conditional');
+// var hasPatterns = require('has-package-exports/pattern');
+
+var getExpected = require('./conditions-expected');
+
+test('condition ordering', function (t) {
+	if (hasBrokenExports) {
+		t.ok(
+			semver.satisfies(process.version, '~13.0 || ~13.1', { includePrerelease: true }),
+			'node ~13.0 || ~13.1: the "exports" field should not work, but does, incorrectly, and only supports a string'
+		);
+	} else if (!hasPackageExports) {
+		t.ok(
+			semver.satisfies(process.version, '<12.17', { includePrerelease: true }),
+			'node < 12.17: no support for the "exports" field'
+		);
+	} else if (!hasConditions) {
+		t.ok(
+			semver.satisfies(process.version, '13.2 - 13.6', { includePrerelease: true }),
+			'node 13.2 - 13.6: supports the "exports" field‘s object form, but no conditions beyond "default"'
+		);
+	} else {
+		t.ok(
+			semver.satisfies(process.version, '^12.17 || ^13.7 || >= 14', { includePrerelease: true }),
+			'node ^12.17 || ^13.7 || >= 14: supports the "exports" field'
+		);
+	}
+
+	forEach([
+		['require.resolve', getExpected(require.resolve)],
+		['resolve', getExpected(function (x) { return resolve.sync(x); })]
+	], function (entry) {
+		var desc = entry[0];
+		var results = entry[1];
+
+		t.test(desc, { todo: desc === 'resolve' }, function (st) {
+			st.deepEqual(
+				Object.keys(results.expected).map(function (e) { return e === '.' ? e : './' + e; }),
+				Object.keys(results['package'].exports),
+				'test expects proper exports'
+			);
+
+			st.equal(whyNotEqual(results.expected, results.actual), '', 'expected exported values match actual exported values');
+			st.deepEqual(results.expected, results.actual);
+
+			st.end();
+		});
+	});
+
+	t.end();
+});

--- a/packages/tests/fixtures/conditions/expected.json
+++ b/packages/tests/fixtures/conditions/expected.json
@@ -1,0 +1,445 @@
+{
+	"name": "conditions",
+	"version": "0.0.0",
+	"engines": {
+		"node": "*"
+	},
+	"binaries": [],
+	"require": [
+		"conditions",
+		"conditions/dinr",
+		"conditions/dirn",
+		"conditions/dnir",
+		"conditions/dnri",
+		"conditions/drin",
+		"conditions/drni",
+		"conditions/idnr",
+		"conditions/idrn",
+		"conditions/indr",
+		"conditions/inrd",
+		"conditions/irdn",
+		"conditions/irnd",
+		"conditions/ndir",
+		"conditions/ndri",
+		"conditions/nidr",
+		"conditions/nird",
+		"conditions/nrdi",
+		"conditions/nrid",
+		"conditions/package.json",
+		"conditions/rdin",
+		"conditions/rdni",
+		"conditions/ridn",
+		"conditions/rind",
+		"conditions/rndi",
+		"conditions/rnid"
+	],
+	"import": [
+		"conditions",
+		"conditions/dinr",
+		"conditions/dirn",
+		"conditions/dnir",
+		"conditions/dnri",
+		"conditions/drin",
+		"conditions/drni",
+		"conditions/idnr",
+		"conditions/idrn",
+		"conditions/indr",
+		"conditions/inrd",
+		"conditions/irdn",
+		"conditions/irnd",
+		"conditions/ndir",
+		"conditions/ndri",
+		"conditions/nidr",
+		"conditions/nird",
+		"conditions/nrdi",
+		"conditions/nrid",
+		"conditions/package.json",
+		"conditions/rdin",
+		"conditions/rdni",
+		"conditions/ridn",
+		"conditions/rind",
+		"conditions/rndi",
+		"conditions/rnid"
+	],
+	"files": [
+		"./default.js",
+		"./fallback.js",
+		"./import.mjs",
+		"./node.js",
+		"./package.json",
+		"./require.js"
+	],
+	"tree": {
+		"conditions": {
+			"default.js": [
+				"conditions",
+				"conditions/dinr",
+				"conditions/dirn",
+				"conditions/dnir",
+				"conditions/dnri",
+				"conditions/drin",
+				"conditions/drni",
+				"conditions/idnr",
+				"conditions/idrn",
+				"conditions/indr",
+				"conditions/inrd",
+				"conditions/irdn",
+				"conditions/irnd",
+				"conditions/ndir",
+				"conditions/ndri",
+				"conditions/nidr",
+				"conditions/nird",
+				"conditions/nrdi",
+				"conditions/nrid",
+				"conditions/rdin",
+				"conditions/rdni",
+				"conditions/ridn",
+				"conditions/rind",
+				"conditions/rndi",
+				"conditions/rnid"
+			],
+			"fallback.js": [
+				"conditions",
+				"conditions/dinr",
+				"conditions/dirn",
+				"conditions/dnir",
+				"conditions/dnri",
+				"conditions/drin",
+				"conditions/drni",
+				"conditions/idnr",
+				"conditions/idrn",
+				"conditions/indr",
+				"conditions/inrd",
+				"conditions/irdn",
+				"conditions/irnd",
+				"conditions/ndir",
+				"conditions/ndri",
+				"conditions/nidr",
+				"conditions/nird",
+				"conditions/nrdi",
+				"conditions/nrid",
+				"conditions/rdin",
+				"conditions/rdni",
+				"conditions/ridn",
+				"conditions/rind",
+				"conditions/rndi",
+				"conditions/rnid"
+			],
+			"package.json": [
+				"conditions/package.json"
+			],
+			"node.js": [
+				"conditions/dinr",
+				"conditions/dirn",
+				"conditions/dnir",
+				"conditions/dnri",
+				"conditions/drin",
+				"conditions/drni",
+				"conditions/idnr",
+				"conditions/idrn",
+				"conditions/indr",
+				"conditions/inrd",
+				"conditions/irdn",
+				"conditions/irnd",
+				"conditions/ndir",
+				"conditions/ndri",
+				"conditions/nidr",
+				"conditions/nird",
+				"conditions/nrdi",
+				"conditions/nrid",
+				"conditions/rdin",
+				"conditions/rdni",
+				"conditions/ridn",
+				"conditions/rind",
+				"conditions/rndi",
+				"conditions/rnid"
+			],
+			"require.js": [
+				"conditions/dinr",
+				"conditions/dirn",
+				"conditions/dnir",
+				"conditions/dnri",
+				"conditions/drin",
+				"conditions/drni",
+				"conditions/idnr",
+				"conditions/idrn",
+				"conditions/indr",
+				"conditions/inrd",
+				"conditions/irdn",
+				"conditions/irnd",
+				"conditions/ndir",
+				"conditions/ndri",
+				"conditions/nidr",
+				"conditions/nird",
+				"conditions/nrdi",
+				"conditions/nrid",
+				"conditions/rdin",
+				"conditions/rdni",
+				"conditions/ridn",
+				"conditions/rind",
+				"conditions/rndi",
+				"conditions/rnid"
+			],
+			"import.mjs": [
+				"conditions/dinr",
+				"conditions/dirn",
+				"conditions/dnir",
+				"conditions/dnri",
+				"conditions/drin",
+				"conditions/drni",
+				"conditions/idnr",
+				"conditions/idrn",
+				"conditions/indr",
+				"conditions/inrd",
+				"conditions/irdn",
+				"conditions/irnd",
+				"conditions/ndir",
+				"conditions/ndri",
+				"conditions/nidr",
+				"conditions/nird",
+				"conditions/nrdi",
+				"conditions/nrid",
+				"conditions/rdin",
+				"conditions/rdni",
+				"conditions/ridn",
+				"conditions/rind",
+				"conditions/rndi",
+				"conditions/rnid"
+			]
+		}
+	},
+	"require (pre-exports)": [
+		"conditions",
+		"conditions/",
+		"conditions/default",
+		"conditions/default.js",
+		"conditions/dinr",
+		"conditions/dinr.js",
+		"conditions/dirn",
+		"conditions/dirn.js",
+		"conditions/dnir",
+		"conditions/dnir.js",
+		"conditions/dnri",
+		"conditions/dnri.js",
+		"conditions/drin",
+		"conditions/drin.js",
+		"conditions/drni",
+		"conditions/drni.js",
+		"conditions/fallback",
+		"conditions/fallback.js",
+		"conditions/gen",
+		"conditions/gen.js",
+		"conditions/idnr",
+		"conditions/idnr.js",
+		"conditions/idrn",
+		"conditions/idrn.js",
+		"conditions/indr",
+		"conditions/indr.js",
+		"conditions/inrd",
+		"conditions/inrd.js",
+		"conditions/irdn",
+		"conditions/irdn.js",
+		"conditions/irnd",
+		"conditions/irnd.js",
+		"conditions/main",
+		"conditions/main.js",
+		"conditions/ndir",
+		"conditions/ndir.js",
+		"conditions/ndri",
+		"conditions/ndri.js",
+		"conditions/nidr",
+		"conditions/nidr.js",
+		"conditions/nird",
+		"conditions/nird.js",
+		"conditions/node",
+		"conditions/node.js",
+		"conditions/nrdi",
+		"conditions/nrdi.js",
+		"conditions/nrid",
+		"conditions/nrid.js",
+		"conditions/package",
+		"conditions/package.json",
+		"conditions/rdin",
+		"conditions/rdin.js",
+		"conditions/rdni",
+		"conditions/rdni.js",
+		"conditions/require",
+		"conditions/require.js",
+		"conditions/ridn",
+		"conditions/ridn.js",
+		"conditions/rind",
+		"conditions/rind.js",
+		"conditions/rndi",
+		"conditions/rndi.js",
+		"conditions/rnid",
+		"conditions/rnid.js"
+	],
+	"files (pre-exports)": [
+		"./default.js",
+		"./dinr.js",
+		"./dirn.js",
+		"./dnir.js",
+		"./dnri.js",
+		"./drin.js",
+		"./drni.js",
+		"./fallback.js",
+		"./gen.js",
+		"./idnr.js",
+		"./idrn.js",
+		"./import.mjs",
+		"./indr.js",
+		"./inrd.js",
+		"./irdn.js",
+		"./irnd.js",
+		"./main.js",
+		"./ndir.js",
+		"./ndri.js",
+		"./nidr.js",
+		"./nird.js",
+		"./node.js",
+		"./nrdi.js",
+		"./nrid.js",
+		"./package.json",
+		"./rdin.js",
+		"./rdni.js",
+		"./require.js",
+		"./ridn.js",
+		"./rind.js",
+		"./rndi.js",
+		"./rnid.js"
+	],
+	"tree (pre-exports)": {
+		"conditions": {
+			"main.js": [
+				"conditions",
+				"conditions/",
+				"conditions/main",
+				"conditions/main.js"
+			],
+			"default.js": [
+				"conditions/default",
+				"conditions/default.js"
+			],
+			"dinr.js": [
+				"conditions/dinr",
+				"conditions/dinr.js"
+			],
+			"dirn.js": [
+				"conditions/dirn",
+				"conditions/dirn.js"
+			],
+			"dnir.js": [
+				"conditions/dnir",
+				"conditions/dnir.js"
+			],
+			"dnri.js": [
+				"conditions/dnri",
+				"conditions/dnri.js"
+			],
+			"drin.js": [
+				"conditions/drin",
+				"conditions/drin.js"
+			],
+			"drni.js": [
+				"conditions/drni",
+				"conditions/drni.js"
+			],
+			"fallback.js": [
+				"conditions/fallback",
+				"conditions/fallback.js"
+			],
+			"gen.js": [
+				"conditions/gen",
+				"conditions/gen.js"
+			],
+			"idnr.js": [
+				"conditions/idnr",
+				"conditions/idnr.js"
+			],
+			"idrn.js": [
+				"conditions/idrn",
+				"conditions/idrn.js"
+			],
+			"import.mjs": [
+				"conditions/import.mjs"
+			],
+			"indr.js": [
+				"conditions/indr",
+				"conditions/indr.js"
+			],
+			"inrd.js": [
+				"conditions/inrd",
+				"conditions/inrd.js"
+			],
+			"irdn.js": [
+				"conditions/irdn",
+				"conditions/irdn.js"
+			],
+			"irnd.js": [
+				"conditions/irnd",
+				"conditions/irnd.js"
+			],
+			"ndir.js": [
+				"conditions/ndir",
+				"conditions/ndir.js"
+			],
+			"ndri.js": [
+				"conditions/ndri",
+				"conditions/ndri.js"
+			],
+			"nidr.js": [
+				"conditions/nidr",
+				"conditions/nidr.js"
+			],
+			"nird.js": [
+				"conditions/nird",
+				"conditions/nird.js"
+			],
+			"node.js": [
+				"conditions/node",
+				"conditions/node.js"
+			],
+			"nrdi.js": [
+				"conditions/nrdi",
+				"conditions/nrdi.js"
+			],
+			"nrid.js": [
+				"conditions/nrid",
+				"conditions/nrid.js"
+			],
+			"package.json": [
+				"conditions/package",
+				"conditions/package.json"
+			],
+			"rdin.js": [
+				"conditions/rdin",
+				"conditions/rdin.js"
+			],
+			"rdni.js": [
+				"conditions/rdni",
+				"conditions/rdni.js"
+			],
+			"require.js": [
+				"conditions/require",
+				"conditions/require.js"
+			],
+			"ridn.js": [
+				"conditions/ridn",
+				"conditions/ridn.js"
+			],
+			"rind.js": [
+				"conditions/rind",
+				"conditions/rind.js"
+			],
+			"rndi.js": [
+				"conditions/rndi",
+				"conditions/rndi.js"
+			],
+			"rnid.js": [
+				"conditions/rnid",
+				"conditions/rnid.js"
+			]
+		}
+	},
+	"errors": []
+}

--- a/packages/tests/fixtures/conditions/project/default.js
+++ b/packages/tests/fixtures/conditions/project/default.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'default';

--- a/packages/tests/fixtures/conditions/project/dinr.js
+++ b/packages/tests/fixtures/conditions/project/dinr.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'dinr';

--- a/packages/tests/fixtures/conditions/project/dirn.js
+++ b/packages/tests/fixtures/conditions/project/dirn.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'dirn';

--- a/packages/tests/fixtures/conditions/project/dnir.js
+++ b/packages/tests/fixtures/conditions/project/dnir.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'dnir';

--- a/packages/tests/fixtures/conditions/project/dnri.js
+++ b/packages/tests/fixtures/conditions/project/dnri.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'dnri';

--- a/packages/tests/fixtures/conditions/project/drin.js
+++ b/packages/tests/fixtures/conditions/project/drin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'drin';

--- a/packages/tests/fixtures/conditions/project/drni.js
+++ b/packages/tests/fixtures/conditions/project/drni.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'drni';

--- a/packages/tests/fixtures/conditions/project/fallback.js
+++ b/packages/tests/fixtures/conditions/project/fallback.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'fallback';

--- a/packages/tests/fixtures/conditions/project/gen.js
+++ b/packages/tests/fixtures/conditions/project/gen.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const isTest = process.env.NODE_ENV === 'test';
+
+const conditions = ['default', 'node', 'require', 'import'];
+const conditionsMap = Object.fromEntries(conditions.map((c) => [c.charAt(0), c]));
+
+// from https://staff.roguecc.edu/JMiller/JavaScript/permute.html
+const permutations = [];
+const usedChars = [];
+// eslint-disable-next-line func-style
+function permute(input) {
+	// convert input into a char array (one element for each character)
+	const chars = input.split('');
+	for (let i = 0; i < chars.length; i++) {
+		// get and remove character at index "i" from char array
+		const ch = chars.splice(i, 1);
+		// add removed character to the end of used characters
+		usedChars.push(ch);
+		// when there are no more characters left in char array to add, add used chars to list of permutations
+		if (chars.length === 0) {
+			permutations[permutations.length] = usedChars.join('');
+		}
+		// send characters (minus the removed one from above) from char array to be permuted
+		permute(chars.join(''));
+		// add removed character back into char array in original position
+		chars.splice(i, 0, ch);
+		// remove the last character used off the end of used characters array
+		usedChars.pop();
+	}
+}
+permute(Object.keys(conditionsMap).join(''));
+
+const pkg = {
+	name: 'conditions',
+	version: '0.0.0',
+	main: './main.js',
+	exports: {
+		'.': [
+			{
+				'default': './default.js'
+			},
+			'./fallback.js'
+		],
+		'./package.json': './package.json',
+		...Object.fromEntries(permutations.map((word) => {
+			const chars = word.split('');
+			return [`./${word}`, [
+				Object.fromEntries(chars.map((c) => [conditionsMap[c], `./${conditionsMap[c]}.${conditionsMap[c] === 'import' ? 'm' : ''}js`])),
+				'./fallback.js'
+			]];
+		}))
+	},
+	permutations: permutations
+};
+
+const pkgJSONpath = path.join(__dirname, 'package.json');
+const pkgJSONcontents = JSON.stringify(pkg, null, '\t');
+if (isTest) {
+	var actual = String(fs.readFileSync(pkgJSONpath));
+	assert.equal(actual, pkgJSONcontents);
+} else {
+	fs.writeFileSync(pkgJSONpath, pkgJSONcontents);
+}
+
+permutations.forEach((permutation) => {
+	const permPath = path.join(__dirname, `${permutation}.js`);
+	const contents = `'use strict';
+
+module.exports = '${permutation}';
+`;
+	if (isTest) {
+		const actualContents = String(fs.readFileSync(permPath));
+		assert.equal(actualContents, contents);
+	} else {
+		fs.writeFileSync(permPath, contents);
+	}
+});

--- a/packages/tests/fixtures/conditions/project/idnr.js
+++ b/packages/tests/fixtures/conditions/project/idnr.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'idnr';

--- a/packages/tests/fixtures/conditions/project/idrn.js
+++ b/packages/tests/fixtures/conditions/project/idrn.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'idrn';

--- a/packages/tests/fixtures/conditions/project/import.mjs
+++ b/packages/tests/fixtures/conditions/project/import.mjs
@@ -1,0 +1,1 @@
+export default 'import';

--- a/packages/tests/fixtures/conditions/project/indr.js
+++ b/packages/tests/fixtures/conditions/project/indr.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'indr';

--- a/packages/tests/fixtures/conditions/project/inrd.js
+++ b/packages/tests/fixtures/conditions/project/inrd.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'inrd';

--- a/packages/tests/fixtures/conditions/project/irdn.js
+++ b/packages/tests/fixtures/conditions/project/irdn.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'irdn';

--- a/packages/tests/fixtures/conditions/project/irnd.js
+++ b/packages/tests/fixtures/conditions/project/irnd.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'irnd';

--- a/packages/tests/fixtures/conditions/project/main.js
+++ b/packages/tests/fixtures/conditions/project/main.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'main';

--- a/packages/tests/fixtures/conditions/project/ndir.js
+++ b/packages/tests/fixtures/conditions/project/ndir.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'ndir';

--- a/packages/tests/fixtures/conditions/project/ndri.js
+++ b/packages/tests/fixtures/conditions/project/ndri.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'ndri';

--- a/packages/tests/fixtures/conditions/project/nidr.js
+++ b/packages/tests/fixtures/conditions/project/nidr.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'nidr';

--- a/packages/tests/fixtures/conditions/project/nird.js
+++ b/packages/tests/fixtures/conditions/project/nird.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'nird';

--- a/packages/tests/fixtures/conditions/project/node.js
+++ b/packages/tests/fixtures/conditions/project/node.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'node';

--- a/packages/tests/fixtures/conditions/project/nrdi.js
+++ b/packages/tests/fixtures/conditions/project/nrdi.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'nrdi';

--- a/packages/tests/fixtures/conditions/project/nrid.js
+++ b/packages/tests/fixtures/conditions/project/nrid.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'nrid';

--- a/packages/tests/fixtures/conditions/project/package.json
+++ b/packages/tests/fixtures/conditions/project/package.json
@@ -1,0 +1,256 @@
+{
+	"name": "conditions",
+	"version": "0.0.0",
+	"main": "./main.js",
+	"exports": {
+		".": [
+			{
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		],
+		"./package.json": "./package.json",
+		"./dnri": [
+			{
+				"default": "./default.js",
+				"node": "./node.js",
+				"require": "./require.js",
+				"import": "./import.mjs"
+			},
+			"./fallback.js"
+		],
+		"./dnir": [
+			{
+				"default": "./default.js",
+				"node": "./node.js",
+				"import": "./import.mjs",
+				"require": "./require.js"
+			},
+			"./fallback.js"
+		],
+		"./drni": [
+			{
+				"default": "./default.js",
+				"require": "./require.js",
+				"node": "./node.js",
+				"import": "./import.mjs"
+			},
+			"./fallback.js"
+		],
+		"./drin": [
+			{
+				"default": "./default.js",
+				"require": "./require.js",
+				"import": "./import.mjs",
+				"node": "./node.js"
+			},
+			"./fallback.js"
+		],
+		"./dinr": [
+			{
+				"default": "./default.js",
+				"import": "./import.mjs",
+				"node": "./node.js",
+				"require": "./require.js"
+			},
+			"./fallback.js"
+		],
+		"./dirn": [
+			{
+				"default": "./default.js",
+				"import": "./import.mjs",
+				"require": "./require.js",
+				"node": "./node.js"
+			},
+			"./fallback.js"
+		],
+		"./ndri": [
+			{
+				"node": "./node.js",
+				"default": "./default.js",
+				"require": "./require.js",
+				"import": "./import.mjs"
+			},
+			"./fallback.js"
+		],
+		"./ndir": [
+			{
+				"node": "./node.js",
+				"default": "./default.js",
+				"import": "./import.mjs",
+				"require": "./require.js"
+			},
+			"./fallback.js"
+		],
+		"./nrdi": [
+			{
+				"node": "./node.js",
+				"require": "./require.js",
+				"default": "./default.js",
+				"import": "./import.mjs"
+			},
+			"./fallback.js"
+		],
+		"./nrid": [
+			{
+				"node": "./node.js",
+				"require": "./require.js",
+				"import": "./import.mjs",
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		],
+		"./nidr": [
+			{
+				"node": "./node.js",
+				"import": "./import.mjs",
+				"default": "./default.js",
+				"require": "./require.js"
+			},
+			"./fallback.js"
+		],
+		"./nird": [
+			{
+				"node": "./node.js",
+				"import": "./import.mjs",
+				"require": "./require.js",
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		],
+		"./rdni": [
+			{
+				"require": "./require.js",
+				"default": "./default.js",
+				"node": "./node.js",
+				"import": "./import.mjs"
+			},
+			"./fallback.js"
+		],
+		"./rdin": [
+			{
+				"require": "./require.js",
+				"default": "./default.js",
+				"import": "./import.mjs",
+				"node": "./node.js"
+			},
+			"./fallback.js"
+		],
+		"./rndi": [
+			{
+				"require": "./require.js",
+				"node": "./node.js",
+				"default": "./default.js",
+				"import": "./import.mjs"
+			},
+			"./fallback.js"
+		],
+		"./rnid": [
+			{
+				"require": "./require.js",
+				"node": "./node.js",
+				"import": "./import.mjs",
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		],
+		"./ridn": [
+			{
+				"require": "./require.js",
+				"import": "./import.mjs",
+				"default": "./default.js",
+				"node": "./node.js"
+			},
+			"./fallback.js"
+		],
+		"./rind": [
+			{
+				"require": "./require.js",
+				"import": "./import.mjs",
+				"node": "./node.js",
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		],
+		"./idnr": [
+			{
+				"import": "./import.mjs",
+				"default": "./default.js",
+				"node": "./node.js",
+				"require": "./require.js"
+			},
+			"./fallback.js"
+		],
+		"./idrn": [
+			{
+				"import": "./import.mjs",
+				"default": "./default.js",
+				"require": "./require.js",
+				"node": "./node.js"
+			},
+			"./fallback.js"
+		],
+		"./indr": [
+			{
+				"import": "./import.mjs",
+				"node": "./node.js",
+				"default": "./default.js",
+				"require": "./require.js"
+			},
+			"./fallback.js"
+		],
+		"./inrd": [
+			{
+				"import": "./import.mjs",
+				"node": "./node.js",
+				"require": "./require.js",
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		],
+		"./irdn": [
+			{
+				"import": "./import.mjs",
+				"require": "./require.js",
+				"default": "./default.js",
+				"node": "./node.js"
+			},
+			"./fallback.js"
+		],
+		"./irnd": [
+			{
+				"import": "./import.mjs",
+				"require": "./require.js",
+				"node": "./node.js",
+				"default": "./default.js"
+			},
+			"./fallback.js"
+		]
+	},
+	"permutations": [
+		"dnri",
+		"dnir",
+		"drni",
+		"drin",
+		"dinr",
+		"dirn",
+		"ndri",
+		"ndir",
+		"nrdi",
+		"nrid",
+		"nidr",
+		"nird",
+		"rdni",
+		"rdin",
+		"rndi",
+		"rnid",
+		"ridn",
+		"rind",
+		"idnr",
+		"idrn",
+		"indr",
+		"inrd",
+		"irdn",
+		"irnd"
+	]
+}

--- a/packages/tests/fixtures/conditions/project/rdin.js
+++ b/packages/tests/fixtures/conditions/project/rdin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'rdin';

--- a/packages/tests/fixtures/conditions/project/rdni.js
+++ b/packages/tests/fixtures/conditions/project/rdni.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'rdni';

--- a/packages/tests/fixtures/conditions/project/require.js
+++ b/packages/tests/fixtures/conditions/project/require.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'require';

--- a/packages/tests/fixtures/conditions/project/ridn.js
+++ b/packages/tests/fixtures/conditions/project/ridn.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'ridn';

--- a/packages/tests/fixtures/conditions/project/rind.js
+++ b/packages/tests/fixtures/conditions/project/rind.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'rind';

--- a/packages/tests/fixtures/conditions/project/rndi.js
+++ b/packages/tests/fixtures/conditions/project/rndi.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'rndi';

--- a/packages/tests/fixtures/conditions/project/rnid.js
+++ b/packages/tests/fixtures/conditions/project/rnid.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'rnid';

--- a/packages/tests/index.js
+++ b/packages/tests/index.js
@@ -25,7 +25,7 @@ test('listExports', (t) => {
 	fixtures.forEach((fixture) => {
 		const skip = re && !re.test(fixture);
 		t.test(`fixture: ${fixture}`, { skip: skip }, async (st) => {
-			const checkNPM = !isOffline && !fixture.startsWith('ex-') && fixture !== 'list-exports' && fixture !== 'ls-exports';
+			const checkNPM = !isOffline && !fixture.startsWith('ex-') && fixture !== 'list-exports' && fixture !== 'ls-exports' && fixture !== 'conditions';
 			st.plan(2);
 
 			const fixtureDir = path.join(fixturesDir, fixture);

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,14 +4,24 @@
 	"private": true,
 	"scripts": {
 		"lint": "eslint .",
-		"pretest": "npm run lint"
+		"pretest": "npm run lint",
+		"posttest": "NODE_ENV=test npm run regen",
+		"regen": "node fixtures/conditions/project/gen"
 	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^17.2.0",
+		"conditions": "file:./fixtures/conditions/project",
 		"eslint": "^7.11.0",
+		"for-each": "^0.3.3",
+		"has-package-exports": "^1.2.1",
+		"is-equal": "^1.6.1",
 		"json-diff": "^0.5.4",
 		"list-exports": "*",
 		"ls-engines": "^0.3.5",
+		"object.entries": "^1.1.2",
+		"object.fromentries": "^2.0.2",
+		"resolve": "^2.0.0-next.1",
+		"semver": "^6.3.0",
 		"tape": "^5.0.1"
 	},
 	"engines": {


### PR DESCRIPTION
Add tests that cover the ordering of conditions in every node version.

TODO: add `import()` tests for testing the import versions. Not sure how to do this since there's no ESM resolver in node.